### PR TITLE
Allow multiple names to be specified for a single context

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -1,0 +1,2 @@
+ruby:
+  config_file: .rubocop.yml

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,54 @@
+ClassAndModuleChildren:
+  Include:
+    - lib/**/*.rb
+Documentation:
+  Enabled: false
+EmptyLinesAroundBlockBody:
+  Enabled: false
+EmptyLinesAroundClassBody:
+  Enabled: false
+EmptyLinesAroundModuleBody:
+  Enabled: false
+ExtraSpacing:
+  Enabled: false
+LineLength:
+  # Default is that lines should be 80, but that's somewhat noisy. We want a softer limit.
+  Description: Limit lines to 120 characters.
+  Max: 120
+  Exclude:
+    - config/routes.rb
+Lint/EndAlignment:
+  # The value `keyword` means that `end` should be aligned with the matching
+  # keyword (if, while, etc.).
+  # The value `variable` means that in assignments, `end` should be aligned
+  # with the start of the variable on the left hand side of `=`. In all other
+  # situations, `end` should still be aligned with the keyword.
+  AlignWith: variable
+  SupportedStyles:
+    - keyword
+    - variable
+Lint/UnusedMethodArgument:
+  Exclude:
+    - app/interactors/**/*.rb
+Lint/UselessAccessModifier:
+  Enabled: false
+SingleSpaceBeforeFirstArg:
+  Enabled: false
+SpaceInsideBrackets:
+  Enabled: false
+StringLiterals:
+  EnforcedStyle: single_quotes
+  Enabled: true
+Style/Blocks:
+  Enabled: false
+Style/CollectionMethods:
+  PreferredMethods:
+    find: 'detect'
+Style/BracesAroundHashParameters:
+  EnforcedStyle: context_dependent
+  SupportedStyles:
+    - braces
+    - no_braces
+    - context_dependent
+Style/IndentHash:
+  Enabled: false

--- a/lib/render_pipeline/configuration.rb
+++ b/lib/render_pipeline/configuration.rb
@@ -79,8 +79,11 @@ module RenderPipeline
     end
 
     self.render_contexts = { 'default' => { block: proc {} } }
-    def self.render_context(name = :default, &block)
-      render_contexts[name.to_s] = { block: block, instance: Context.new(&block) }
+    def self.render_context(*names, &block)
+      names.push(:default) if names.size == 0
+      names.each do |name|
+        render_contexts[name.to_s] = { block: block, instance: Context.new(&block) }
+      end
     end
 
     def self.render_context_for(name)

--- a/lib/render_pipeline/configuration.rb
+++ b/lib/render_pipeline/configuration.rb
@@ -80,7 +80,7 @@ module RenderPipeline
 
     self.render_contexts = { 'default' => { block: proc {} } }
     def self.render_context(*names, &block)
-      names.push(:default) if names.size == 0
+      names.push(:default) if names.empty?
       names.each do |name|
         render_contexts[name.to_s] = { block: block, instance: Context.new(&block) }
       end

--- a/render_pipeline.gemspec
+++ b/render_pipeline.gemspec
@@ -31,4 +31,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'bundler'
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rspec'
+  s.add_development_dependency 'pry'
 end

--- a/spec/render_pipeline/configuration_spec.rb
+++ b/spec/render_pipeline/configuration_spec.rb
@@ -9,6 +9,32 @@ describe RenderPipeline::Configuration do
     RenderPipeline.configuration.sanitize_rules = old
   end
 
-  it 'allows configuring contexts'
+  describe 'configuring contexts' do
+    it 'configures a default context when no name is provided' do
+      RenderPipeline.configure do |config|
+        config.render_context do |c|
+          c.host_name = 'example.com'
+        end
+      end
+      default_context = RenderPipeline.configuration.render_contexts['default'][:instance]
+      expect(default_context.host_name).to eq('example.com')
+    end
 
+    it 'configures a named context when a name is provided' do
+      RenderPipeline.configure do |c|
+        c.render_context :nondefault do
+        end
+      end
+      expect(RenderPipeline.configuration.render_contexts).to have_key('nondefault')
+    end
+
+    it 'configures multiple identical named contexts when multiple names are provided' do
+      RenderPipeline.configure do |c|
+        c.render_context :nondefault, :extranondefault do
+        end
+      end
+      expect(RenderPipeline.configuration.render_contexts).to have_key('nondefault')
+      expect(RenderPipeline.configuration.render_contexts).to have_key('extranondefault')
+    end
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,21 +1,22 @@
 require 'render_pipeline'
 require 'rspec'
 require 'active_support/core_ext/string/strip'
+require 'pry'
 
 RSpec.configure do |config|
-end
+  config.before(:each) do
+    RenderPipeline.configuration.render_contexts = { 'default' => { block: proc {} } }
+    RenderPipeline.configure do |render_config|
+      render_config.add_emoji 'ello'
 
-RenderPipeline.configure do |config|
+      render_config.render_context :default do |c|
+        c.asset_root = "http://example.com/images"
+        c.hashtag_root = "http://example.com/search"
+      end
 
-  config.add_emoji 'ello'
-
-  config.render_context :default do |c|
-    c.asset_root = "http://example.com/images"
-    c.hashtag_root = "http://example.com/search"
+      render_config.render_context :lite do |c|
+        c.render_filters = RenderPipeline.configuration.render_filters - [RenderPipeline::Filter::ImageAdjustments]
+      end
+    end
   end
-
-  config.render_context :lite do |c|
-    c.render_filters = RenderPipeline.configuration.render_filters - [RenderPipeline::Filter::ImageAdjustments]
-  end
-
 end


### PR DESCRIPTION
Makes it easier to effectively alias contexts.

Also add pry for debugging tests