### PR TITLE
Allow truncation to be specified for a context

### DIFF
--- a/lib/render_pipeline/configuration.rb
+++ b/lib/render_pipeline/configuration.rb
@@ -52,7 +52,10 @@ module RenderPipeline
         :hashtag_root,
         :hashtag_pattern,
         :hashtag_ignored_ancestor_tags,
-        :hashtag_classlist
+        :hashtag_classlist,
+        # truncation
+        :truncate_length,
+        :truncate_tail
       ]
       attr_accessor(*SETTINGS)
 
@@ -67,6 +70,7 @@ module RenderPipeline
         @hashtag_classlist = 'hashtag-link'
         @hashtag_pattern = /\B(#\w+)/
         @hashtag_ignored_ancestor_tags = ''
+        @truncate_tail = '...'
 
         default = RenderPipeline.configuration.render_contexts['default']
         instance_eval(&default[:block]) if default

--- a/lib/render_pipeline/renderer.rb
+++ b/lib/render_pipeline/renderer.rb
@@ -7,16 +7,16 @@ module RenderPipeline
       @render_version_key = RenderPipeline.configuration.render_version_key
     end
 
-    def render(options = {})
-      context = RenderPipeline.configuration.render_context_for(options[:context] || :default)
-      cache(options) do
-        result = pipeline(context).call(clean_content)[:output].to_s
-        if options[:truncate]
-          tail = options[:truncate_tail] || '...'
-          Truncato.truncate(result, max_length: options[:truncate], count_tags: false, tail: tail).html_safe
-        else
-          result.html_safe
-        end
+    def render(context: :default)
+      context = RenderPipeline.configuration.render_context_for(context)
+      result = pipeline(context).call(clean_content)[:output].to_s
+      if context[:truncate_length] && context[:truncate_tail]
+        Truncato.truncate(result,
+                          max_length: context[:truncate_length],
+                          count_tags: false,
+                          tail: context[:truncate_tail]).html_safe
+      else
+        result.html_safe
       end
     end
 
@@ -31,48 +31,6 @@ module RenderPipeline
         .gsub(/\<br\>/, "\r\n")
         .gsub(/\u00a0/, ' ')
         .gsub(/&nbsp;/, ' ')
-    end
-
-    def cache(options, &block)
-      if cache = RenderPipeline.configuration.cache
-        md5hash = hexdigest(options.merge(content: @content.to_s))
-        cache.fetch(cache_key(md5hash), &block)
-      else
-        yield
-      end
-    end
-
-    def cache_key(md5hash)
-      [@render_version_key, md5hash].join()
-    end
-
-    # https://github.com/github/linguist/blob/master/lib/linguist/md5.rb#L1
-    # Stolen from github-linguist since that is all we appear to be using
-    # at this point.
-    def hexdigest(obj)
-      digest = Digest::MD5.new
-
-      case obj
-      when String, Symbol, Integer
-        digest.update "#{obj.class}"
-        digest.update "#{obj}"
-      when TrueClass, FalseClass, NilClass
-        digest.update "#{obj.class}"
-      when Array
-        digest.update "#{obj.class}"
-        for e in obj
-          digest.update(hexdigest(e))
-        end
-      when Hash
-        digest.update "#{obj.class}"
-        for e in obj.map { |(k, v)| hexdigest([k, v]) }.sort
-          digest.update(e)
-        end
-      else
-        raise TypeError, "can't convert #{obj.inspect} into String"
-      end
-
-      digest.hexdigest
     end
   end
 end

--- a/render_pipeline.gemspec
+++ b/render_pipeline.gemspec
@@ -16,8 +16,7 @@ Gem::Specification.new do |s|
   s.files       = Dir['{lib}/**/*'] + ['README.md']
   s.test_files  = `git ls-files -- {spec}/*`.split("\n")
 
-  s.add_dependency 'activesupport'
-  s.add_dependency 'nokogiri', '>= 1.6.7.2'
+  s.add_dependency 'nokogiri', '>= 1.6.8'
   s.add_dependency 'html-pipeline', '~> 2.0'
   s.add_dependency 'rinku'
   s.add_dependency 'gemoji'

--- a/spec/render_pipeline/renderer_spec.rb
+++ b/spec/render_pipeline/renderer_spec.rb
@@ -111,7 +111,7 @@ describe RenderPipeline::Renderer do
   end
 
   it 'can truncate the response' do
-    result = subject.new(content).render(truncate: 13, truncate_tail: '<<<')
+    result = subject.new(content).render(context: :truncate)
     expect("#{result}\n").to eq(<<-HTML.strip_heredoc)
     <p>hey everybody&lt;&lt;&lt;</p>
     HTML
@@ -124,19 +124,4 @@ describe RenderPipeline::Renderer do
     expect(HTML::Pipeline).to receive(:new).with('_render_filters_', hash).and_return(call_stub)
     expect(subject.new(content).render).to eq('_output_')
   end
-
-  it 'caches the results if there is a cache to use (assumes Rails.cache)' do
-    cache_stub = double(fetch: '_cached_output_')
-    expect(RenderPipeline.configuration).to receive(:cache).and_return(cache_stub)
-    expect(cache_stub).to receive(:fetch).with('d0ca634e714f3602976a270a80968943').and_return('_cached_output_')
-    expect(subject.new(content).render).to eq('_cached_output_')
-  end
-
-  it 'caches the results based on options' do
-    cache_stub = double(fetch: '_cached_output_')
-    expect(RenderPipeline.configuration).to receive(:cache).and_return(cache_stub)
-    expect(cache_stub).to receive(:fetch).with('94a838e8df0191dc8995965aa1ea5172').and_return('_cached_output_')
-    expect(subject.new(content).render(foo: 'bar')).to eq('_cached_output_')
-  end
-
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,6 +17,11 @@ RSpec.configure do |config|
       render_config.render_context :lite do |c|
         c.render_filters = RenderPipeline.configuration.render_filters - [RenderPipeline::Filter::ImageAdjustments]
       end
+
+      render_config.render_context :truncate do |c|
+        c.truncate_length = 13
+        c.truncate_tail = '<<<'
+      end
     end
   end
 end


### PR DESCRIPTION
Accepts the `truncate_length` and `truncate_tail` options.

Don’t accept an `options` hash to render anymore.

Get rid of caching since this is no longer intended to be used in that context.

Clean up `activesupport` dependency based on that removal.