### PR TITLE
Remove sanitization API

### DIFF
--- a/lib/render_pipeline.rb
+++ b/lib/render_pipeline.rb
@@ -8,7 +8,6 @@ require 'truncato'
 require 'rumoji'
 require 'pygments'
 require 'fastimage'
-require 'sanitize'
 
 module RenderPipeline
   module Filter
@@ -23,14 +22,9 @@ module RenderPipeline
     autoload :SyntaxHighlighter, 'render_pipeline/filters/syntax_highlighter'
   end
 
-  def self.sanitize(html, rules = {})
-    Sanitize.clean(html, RenderPipeline.configuration.sanitize_rules.merge(rules))
-  end
-
   def self.render(content, options = {})
     Renderer.new(content).render(options)
   end
-
 end
 
 require 'render_pipeline/configuration'

--- a/lib/render_pipeline/configuration.rb
+++ b/lib/render_pipeline/configuration.rb
@@ -5,17 +5,9 @@ module RenderPipeline
     include Singleton
 
     class << self
-      attr_accessor :sanitize_rules
       attr_accessor :render_filters, :render_contexts, :render_version_key
       attr_accessor :cache
     end
-
-    self.sanitize_rules = {
-      elements: %w(a b i strong em br),
-      attributes: { 'a' => [ 'href' ] },
-      protocols: { 'a' => { 'href' => [ 'http', 'https', 'mailto' ] } },
-      remove_contents: %w(script embed object style),
-    }
 
     self.render_filters = [
       RenderPipeline::Filter::Mentions,

--- a/render_pipeline.gemspec
+++ b/render_pipeline.gemspec
@@ -25,7 +25,6 @@ Gem::Specification.new do |s|
   s.add_dependency 'rumoji'
   s.add_dependency 'pygments.rb'
   s.add_dependency 'fastimage'
-  s.add_dependency 'sanitize'
 
   s.add_development_dependency 'bundler'
   s.add_development_dependency 'rake'

--- a/spec/render_pipeline/api_spec.rb
+++ b/spec/render_pipeline/api_spec.rb
@@ -2,7 +2,6 @@ require 'spec_helper'
 
 describe RenderPipeline do
   describe '.render' do
-
     it 'should convert @ mentions to links' do
       result = subject.render('<div>@username</div>')
       expect(result).to eq('<div><a href="/username" class="user-mention">@username</a></div>')
@@ -36,37 +35,5 @@ describe RenderPipeline do
         <p><img class="emoji" title=":grin:" alt=":grin:" src="#{src}" height="20" width="20" align="absmiddle"></p>
       HTML
     end
-
-  end
-
-  describe '.sanitize' do
-    let(:html) do
-      <<-HTML.strip_heredoc
-      <script>alert("test")</script>
-      <style>body{}</style>
-      <table>table</table>
-      <a href="ftp://cnn.com" onclick="alert("test")">cnn</a>
-      <a href="javascropt:alert('test')" onclick="alert("test")">cnn</a>
-
-      <a href="mailto:jejacks0n@gmail.com">je<br>jacks0n</a>
-      <a href='http://cnn.com'><i>cnn</i></a>
-      <a href="https://cnn.com"><strong>secure</strong> <em>cnn</em></a>
-      HTML
-    end
-
-    it 'sanitizes the markup' do
-      expect(subject.sanitize(html)).to eq <<-HTML.strip_heredoc
-
-
-      table
-      <a>cnn</a>
-      <a>cnn</a>
-
-      <a href="mailto:jejacks0n@gmail.com">je<br>jacks0n</a>
-      <a href="http://cnn.com"><i>cnn</i></a>
-      <a href="https://cnn.com"><strong>secure</strong> <em>cnn</em></a>
-      HTML
-    end
-
   end
 end

--- a/spec/render_pipeline/configuration_spec.rb
+++ b/spec/render_pipeline/configuration_spec.rb
@@ -1,14 +1,6 @@
 require 'spec_helper'
 
 describe RenderPipeline::Configuration do
-
-  it 'allows configuration' do
-    old = RenderPipeline.configuration.sanitize_rules
-    RenderPipeline.configure { |c| c.sanitize_rules = 'bar' }
-    expect(RenderPipeline.configuration.sanitize_rules).to eql('bar')
-    RenderPipeline.configuration.sanitize_rules = old
-  end
-
   describe 'configuring contexts' do
     it 'configures a default context when no name is provided' do
       RenderPipeline.configure do |config|


### PR DESCRIPTION
It's really just a super-thin wrapper around the sanitize gem, and tangential to the needs of this library for rendering text. Better to have it live at home in the mothership.