### PR TITLE
Reorder emoji filter before Markdown

### DIFF
--- a/lib/render_pipeline/configuration.rb
+++ b/lib/render_pipeline/configuration.rb
@@ -11,10 +11,10 @@ module RenderPipeline
 
     self.render_filters = [
       RenderPipeline::Filter::Mentions,
+      RenderPipeline::Filter::Emoji,
       RenderPipeline::Filter::Markdown,
       RenderPipeline::Filter::Code,
       RenderPipeline::Filter::Hashtag,
-      RenderPipeline::Filter::Emoji,
       RenderPipeline::Filter::LinkAdjustments,
       RenderPipeline::Filter::ImageAdjustments,
     ]

--- a/spec/render_pipeline/renderer_spec.rb
+++ b/spec/render_pipeline/renderer_spec.rb
@@ -50,6 +50,12 @@ describe RenderPipeline::Renderer, vcr: true do
     CONTENT
   end
 
+  let(:emoji) do
+    <<-CONTENT.strip_heredoc
+      :business_suit_levitating:
+    CONTENT
+  end
+
   it 'should only single encode ampersands in URLs' do
     rendered_links = subject.new(broken_links).render
     expect("#{rendered_links}\n").to eq(<<-HTML.strip_heredoc)
@@ -104,6 +110,14 @@ describe RenderPipeline::Renderer, vcr: true do
 
     expect("#{result}\n").to eq(<<-HTML.strip_heredoc)
       <p>[Click me](javascript:alert("Hello!"))</p>
+    HTML
+  end
+
+  it 'properly encodes emoji shortcuts' do
+    result = subject.new(emoji).render
+
+    expect("#{result}\n").to eq(<<-HTML.strip_heredoc)
+      <p><img class="emoji" title=":business_suit_levitating:" alt=":business_suit_levitating:" src="http://example.com/images/emoji/unicode/1f574.png" height="20" width="20" align="absmiddle"></p>
     HTML
   end
 


### PR DESCRIPTION
This was giving us issues with emoji like :business_suit_levitating:
that could be interpreted as Markdown as well.