### PR TITLE
Support Markdown strikethrough with double-tildes

### DIFF
--- a/lib/render_pipeline/configuration.rb
+++ b/lib/render_pipeline/configuration.rb
@@ -10,9 +10,9 @@ module RenderPipeline
     end
 
     self.render_filters = [
-      RenderPipeline::Filter::Mentions,
       RenderPipeline::Filter::Emoji,
       RenderPipeline::Filter::Markdown,
+      RenderPipeline::Filter::Mentions,
       RenderPipeline::Filter::Code,
       RenderPipeline::Filter::Hashtag,
       RenderPipeline::Filter::LinkAdjustments,

--- a/lib/render_pipeline/filters/markdown.rb
+++ b/lib/render_pipeline/filters/markdown.rb
@@ -9,7 +9,10 @@ module RenderPipeline
       private
 
       def parser
-        Redcarpet::Markdown.new(renderer, fenced_code_blocks: true, autolink: true)
+        Redcarpet::Markdown.new(renderer,
+                                fenced_code_blocks: true,
+                                autolink: true,
+                                strikethrough: true)
       end
 
       def renderer

--- a/spec/render_pipeline/renderer_spec.rb
+++ b/spec/render_pipeline/renderer_spec.rb
@@ -56,6 +56,12 @@ describe RenderPipeline::Renderer, vcr: true do
     CONTENT
   end
 
+  let(:strikethrough) do
+    <<-CONTENT.strip_heredoc
+      ~~@ello~~
+    CONTENT
+  end
+
   it 'should only single encode ampersands in URLs' do
     rendered_links = subject.new(broken_links).render
     expect("#{rendered_links}\n").to eq(<<-HTML.strip_heredoc)
@@ -118,6 +124,14 @@ describe RenderPipeline::Renderer, vcr: true do
 
     expect("#{result}\n").to eq(<<-HTML.strip_heredoc)
       <p><img class="emoji" title=":business_suit_levitating:" alt=":business_suit_levitating:" src="http://example.com/images/emoji/unicode/1f574.png" height="20" width="20" align="absmiddle"></p>
+    HTML
+  end
+
+  it 'properly encodes strikethroughs' do
+    result = subject.new(strikethrough).render
+
+    expect("#{result}\n").to eq(<<-HTML.strip_heredoc)
+      <p><del><a href="/ello" class="user-mention">@ello</a></del></p>
     HTML
   end
 


### PR DESCRIPTION
Could probably use a few smoke tests.