### PR TITLE
Remove Rinku dependency

### DIFF
--- a/lib/render_pipeline.rb
+++ b/lib/render_pipeline.rb
@@ -1,7 +1,6 @@
 require 'render_pipeline/version'
 require 'html/pipeline'
 require 'nokogiri'
-require 'rinku'
 require 'gemoji'
 require 'redcarpet'
 require 'truncato'

--- a/render_pipeline.gemspec
+++ b/render_pipeline.gemspec
@@ -19,7 +19,6 @@ Gem::Specification.new do |s|
   s.add_dependency 'activesupport'
   s.add_dependency 'nokogiri', '>= 1.6.8'
   s.add_dependency 'html-pipeline', '~> 2.0'
-  s.add_dependency 'rinku'
   s.add_dependency 'gemoji'
   s.add_dependency 'redcarpet', '>= 3.3.2'
   s.add_dependency 'truncato'


### PR DESCRIPTION
Seems like it's now superfluous. Might as well get rid of it.