### PR TITLE
Ensure that hashtags are linkified before headers

### DIFF
--- a/lib/render_pipeline/configuration.rb
+++ b/lib/render_pipeline/configuration.rb
@@ -11,10 +11,10 @@ module RenderPipeline
 
     self.render_filters = [
       RenderPipeline::Filter::Emoji,
+      RenderPipeline::Filter::Hashtag,
       RenderPipeline::Filter::Markdown,
       RenderPipeline::Filter::Mentions,
       RenderPipeline::Filter::Code,
-      RenderPipeline::Filter::Hashtag,
       RenderPipeline::Filter::LinkAdjustments,
       RenderPipeline::Filter::ImageAdjustments,
     ]

--- a/spec/render_pipeline/renderer_spec.rb
+++ b/spec/render_pipeline/renderer_spec.rb
@@ -62,6 +62,12 @@ describe RenderPipeline::Renderer, vcr: true do
     CONTENT
   end
 
+  let(:hashtag) do
+    <<-CONTENT.strip_heredoc
+      #hashtag
+    CONTENT
+  end
+
   it 'should only single encode ampersands in URLs' do
     rendered_links = subject.new(broken_links).render
     expect("#{rendered_links}\n").to eq(<<-HTML.strip_heredoc)
@@ -132,6 +138,14 @@ describe RenderPipeline::Renderer, vcr: true do
 
     expect("#{result}\n").to eq(<<-HTML.strip_heredoc)
       <p><del><a href="/ello" class="user-mention">@ello</a></del></p>
+    HTML
+  end
+
+  it 'properly encodes hashtags' do
+    result = subject.new(hashtag).render
+
+    expect("#{result}\n").to eq(<<-HTML.strip_heredoc)
+      <p><a href="https://o.ello.co/http://example.com/search?terms=%23hashtag" data-href="http://example.com/search?terms=%23hashtag" data-capture="hashtagClick" class="hashtag-link" rel="nofollow" target="_blank">#hashtag</a></p>
     HTML
   end
 


### PR DESCRIPTION
Since the syntax overlaps, hashtags were being interpreted as H1s. This reverses the order of the filters so that doesn't happen, and adds a spec to help for the future.