### PR TITLE
Ensure mentions with underscores render properly

### DIFF
--- a/lib/render_pipeline/configuration.rb
+++ b/lib/render_pipeline/configuration.rb
@@ -10,10 +10,10 @@ module RenderPipeline
     end
 
     self.render_filters = [
+      RenderPipeline::Filter::Mentions,
       RenderPipeline::Filter::Emoji,
       RenderPipeline::Filter::Hashtag,
       RenderPipeline::Filter::Markdown,
-      RenderPipeline::Filter::Mentions,
       RenderPipeline::Filter::Code,
       RenderPipeline::Filter::LinkAdjustments,
       RenderPipeline::Filter::ImageAdjustments,

--- a/spec/render_pipeline/renderer_spec.rb
+++ b/spec/render_pipeline/renderer_spec.rb
@@ -62,6 +62,12 @@ describe RenderPipeline::Renderer, vcr: true do
     CONTENT
   end
 
+  let(:mention) do
+    <<-CONTENT.strip_heredoc
+      @ello_some_user
+    CONTENT
+  end
+
   let(:hashtag) do
     <<-CONTENT.strip_heredoc
       #hashtag
@@ -133,11 +139,19 @@ describe RenderPipeline::Renderer, vcr: true do
     HTML
   end
 
-  it 'properly encodes strikethroughs' do
+  it 'properly encodes strikethroughs containing mentions' do
     result = subject.new(strikethrough).render
 
     expect("#{result}\n").to eq(<<-HTML.strip_heredoc)
       <p><del><a href="/ello" class="user-mention">@ello</a></del></p>
+    HTML
+  end
+
+  it 'properly encodes mentions' do
+    result = subject.new(mention).render
+
+    expect("#{result}\n").to eq(<<-HTML.strip_heredoc)
+      <p><a href="/ello_some_user" class="user-mention">@ello_some_user</a></p>
     HTML
   end
 


### PR DESCRIPTION
When the Markdown filter ran before the mention filter, it would interpret mentions with underscores in the username as italics. This changes the order so that won't happen, and adds a test to prevent
future breakage.