### PR TITLE
Add `rel="noopener"` to external links

### DIFF
--- a/lib/render_pipeline/filters/link_adjustments.rb
+++ b/lib/render_pipeline/filters/link_adjustments.rb
@@ -21,7 +21,7 @@ module RenderPipeline
 
           # adjust links that are not relative.
           if element['href'][0] != '/'
-            element['rel'] = 'nofollow'
+            element['rel'] = 'nofollow noopener'
             element['target'] = '_blank'
             element['href'] = CGI.unescapeHTML(element['href'])
             element['href'] = (ENV['CLICK_SERVICE_URL'] || 'https://o.ello.co') + '/' + element['href']

--- a/spec/render_pipeline/filters/link_adjustments_spec.rb
+++ b/spec/render_pipeline/filters/link_adjustments_spec.rb
@@ -9,13 +9,21 @@ describe RenderPipeline::Filter::LinkAdjustments do
     expect(result).to eq('<a href="/thomashawk/posts/1">Post</a>')
   end
 
-  it 'adds a nofollow and sets the target on external links' do
+  it 'adds nofollow/noopener to external links' do
     result = subject.to_html('<a href="http://www.example.com/test">Test</a>', context)
-    expect(result).to eq('<a href="https://o.ello.co/http://www.example.com/test" rel="nofollow" target="_blank">Test</a>')
+    a = Nokogiri::XML(result).at_css('a')
+    expect(a['rel']).to eq('nofollow noopener')
+  end
+
+  it 'sets target for external links' do
+    result = subject.to_html('<a href="http://www.example.com/test">Test</a>', context)
+    a = Nokogiri::XML(result).at_css('a')
+    expect(a['target']).to eq('_blank')
   end
 
   it 'prepends the click service url on external links' do
     result = subject.to_html('<a href="http://www.example.com/test">Test</a>', context)
-    expect(result).to eq('<a href="https://o.ello.co/http://www.example.com/test" rel="nofollow" target="_blank">Test</a>')
+    a = Nokogiri::XML(result).at_css('a')
+    expect(a['href']).to eq('https://o.ello.co/http://www.example.com/test')
   end
 end

--- a/spec/render_pipeline/renderer_spec.rb
+++ b/spec/render_pipeline/renderer_spec.rb
@@ -83,14 +83,14 @@ describe RenderPipeline::Renderer, vcr: true do
   it 'should only single encode ampersands in URLs' do
     rendered_links = subject.new(broken_links).render
     expect("#{rendered_links}\n").to eq(<<-HTML.strip_heredoc)
-    <p><a href="#{click_service_url}/http://example.com?one=two&amp;three=4" rel="nofollow" target="_blank">here is code</a></p>
+    <p><a href="#{click_service_url}/http://example.com?one=two&amp;three=4" rel="nofollow noopener" target="_blank">here is code</a></p>
     HTML
   end
 
   it 'should also ignore already encoded ampersands and not replace them' do
     rendered_links = subject.new(encoded_links).render
     expect("#{rendered_links}\n").to eq(<<-HTML.strip_heredoc)
-    <p><a href="#{click_service_url}/http://example.com?one=two&amp;three=4" rel="nofollow" target="_blank">here is code</a></p>
+    <p><a href="#{click_service_url}/http://example.com?one=two&amp;three=4" rel="nofollow noopener" target="_blank">here is code</a></p>
     HTML
   end
 
@@ -172,7 +172,7 @@ describe RenderPipeline::Renderer, vcr: true do
     result = subject.new(hashtag).render
 
     expect("#{result}\n").to eq(<<-HTML.strip_heredoc)
-      <p><a href="https://o.ello.co/http://example.com/search?terms=%23hashtag_with_underscores" data-href="http://example.com/search?terms=%23hashtag_with_underscores" data-capture="hashtagClick" class="hashtag-link" rel="nofollow" target="_blank">#hashtag_with_underscores</a></p>
+      <p><a href="https://o.ello.co/http://example.com/search?terms=%23hashtag_with_underscores" data-href="http://example.com/search?terms=%23hashtag_with_underscores" data-capture="hashtagClick" class="hashtag-link" rel="nofollow noopener" target="_blank">#hashtag_with_underscores</a></p>
     HTML
   end
 


### PR DESCRIPTION
This prevents a phishing/clickjacking bug per https://dev.to/ben/the-targetblank-vulnerability-by-example