### PR TITLE
Properly linkify hashtags containing diacritics

### DIFF
--- a/lib/render_pipeline/configuration.rb
+++ b/lib/render_pipeline/configuration.rb
@@ -53,7 +53,7 @@ module RenderPipeline
         @username_link_cleaner_pattern = /(>@[\w\-]*?)(_{1,3}[\w\-]+_{1,3}[\w\-]*?<\/a>)/
         @hashtag_root = ''
         @hashtag_classlist = 'hashtag-link'
-        @hashtag_pattern = /\B(#\w+)/
+        @hashtag_pattern = /\B(#[[:word:]]+)/
         @hashtag_ignored_ancestor_tags = ''
 
         default = RenderPipeline.configuration.render_contexts['default']

--- a/spec/render_pipeline/renderer_spec.rb
+++ b/spec/render_pipeline/renderer_spec.rb
@@ -185,6 +185,20 @@ describe RenderPipeline::Renderer, vcr: true do
     HTML
   end
 
+  let(:hashtag_with_diacritics) do
+    <<-CONTENT.strip_heredoc
+      #Göteborg
+    CONTENT
+  end
+
+  it 'properly encodes hashtags containing diacritics' do
+    result = subject.new(hashtag_with_diacritics).render
+
+    expect("#{result}\n").to eq(<<-HTML.strip_heredoc)
+      <p><a href="https://o.ello.co/http://example.com/search?terms=%23G%C3%B6teborg" data-href="http://example.com/search?terms=%23Göteborg" data-capture="hashtagClick" class="hashtag-link" rel="nofollow noopener" target="_blank">#Göteborg</a></p>
+    HTML
+  end
+
   it 'properly encodes tables' do
     result = subject.new(table).render
 


### PR DESCRIPTION
Previously we would only recognize hashtags with standard ascii characters - this expands it to any non-whitespace unicode character per http://www.regular-expressions.info/posixbrackets.html

It also will solve the issue of other characters in hashtags potentially blowing up processing of them, though I wonder if we should potentially dial this back to just match `[[:alpha]]` instead of `[[:graph]]` and leave that other issue outstanding. The tables example in https://github.com/ello/render_pipeline/commit/dfc0da56638ae2b46aefef3b4251231fa0d3884c got caught as part of that already, and I could see links with a hash in them potentially getting caught up as well.

@caseydoran @alanpeabody @Justin-Holmes thoughts?