### PR TITLE
Don’t prepend click service if it’s a vimeo link

### DIFF
--- a/lib/render_pipeline/filters/link_adjustments.rb
+++ b/lib/render_pipeline/filters/link_adjustments.rb
@@ -43,11 +43,19 @@ module RenderPipeline
         begin
           uri = URI.parse(element['href'])
           if uri.scheme == 'http' || uri.scheme == 'https'
-            element['href']   = (ENV['CLICK_SERVICE_URL'] || 'https://o.ello.co') + '/' + element['href']
+            element['href']   = adjust_href(element['href'])
             element['target'] = '_blank'
           end
         rescue URI::Error => e
           logger.error("#{e}")
+        end
+      end
+
+      def adjust_href(href)
+        if /vimeo\.com\/(?<id>[0-9]+)/ =~ href
+          href
+        else
+          (ENV['CLICK_SERVICE_URL'] || 'https://o.ello.co') + '/' + href
         end
       end
 

--- a/spec/render_pipeline/filters/link_adjustments_spec.rb
+++ b/spec/render_pipeline/filters/link_adjustments_spec.rb
@@ -32,4 +32,10 @@ describe RenderPipeline::Filter::LinkAdjustments do
     a = Nokogiri::XML(result).at_css('a')
     expect(a['href']).to eq('mailto:asdf@ello.co')
   end
+
+  it 'does not prepend the click service url if external link is a vimeo link' do
+    result = subject.to_html('<a href="https://vimeo.com/215653382">vimeo</a>', context)
+    a = Nokogiri::XML(result).at_css('a')
+    expect(a['href']).to eq('https://vimeo.com/215653382')
+  end
 end


### PR DESCRIPTION
- Vimeo is redirecting to an irrelevant url whenever the click service
is prepended.

https://www.pivotaltracker.com/story/show/151224273